### PR TITLE
add originalRequest to IRequestOptions

### DIFF
--- a/ts/Interfaces.ts
+++ b/ts/Interfaces.ts
@@ -21,6 +21,7 @@ export interface IRequestOptions {
     event?: {name: string, data?: IStringMap};
     sessionId?: string;
     lang?: ApiAiConstants.AVAILABLE_LANGUAGES;
+    originalRequest?: {source: string, data?: IStringMap};
 }
 
 export interface IServerResponse {


### PR DESCRIPTION
This change enabled TypeScript projects to send the originalRequest object, in the same manner as other platforms.